### PR TITLE
RustExpr to separate pretty printing from traverse Agda internals

### DIFF
--- a/agda2rust.cabal
+++ b/agda2rust.cabal
@@ -28,9 +28,10 @@ common warnings
 library
   hs-source-dirs:      src
   exposed-modules:     Agda.Compiler.Rust.Backend
+                       Agda.Compiler.Rust.RustExpr
                        Agda.Compiler.Rust.CommonTypes
-                       Agda.Compiler.Rust.PrettyPrintingUtils
-                       Agda.Compiler.Rust.ToRustCompiler
+                       Agda.Compiler.Rust.PrettyPrintRustExpr
+                       Agda.Compiler.Rust.AgdaToRustExpr
                        Paths_agda2rust
   autogen-modules:     Paths_agda2rust
   build-depends:       base >= 4.10 && < 4.20,

--- a/src/Agda/Compiler/Rust/AgdaToRustExpr.hs
+++ b/src/Agda/Compiler/Rust/AgdaToRustExpr.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE LambdaCase, RecordWildCards #-}
 
-module Agda.Compiler.Rust.ToRustCompiler ( compile, compileModule ) where
+module Agda.Compiler.Rust.AgdaToRustExpr ( compile, compileModule ) where
 
 import Control.Monad.IO.Class ( MonadIO(liftIO) )
 import qualified Data.List.NonEmpty as Nel

--- a/src/Agda/Compiler/Rust/Backend.hs
+++ b/src/Agda/Compiler/Rust/Backend.hs
@@ -3,7 +3,7 @@ module Agda.Compiler.Rust.Backend (
   backend,
   defaultOptions ) where
 
-import Control.Monad ( unless )
+import Control.Monad ( when )
 import Control.Monad.IO.Class ( MonadIO(liftIO) )
 import Control.DeepSeq ( NFData(..) )
 import Data.Maybe ( fromMaybe )
@@ -80,7 +80,7 @@ writeModule :: Options
 writeModule opts _ _ mName cdefs = do
   outDir <- compileDir
   compileLog $ "compiling " <> fileName
-  unless (null cdefs) $ liftIO
+  when (null cdefs) $ liftIO
     $ writeFile (outFile outDir)
     $ prettyPrintRustExpr (compileModule mName cdefs)
   where

--- a/src/Agda/Compiler/Rust/Backend.hs
+++ b/src/Agda/Compiler/Rust/Backend.hs
@@ -24,6 +24,7 @@ import Agda.TypeChecking.Monad (
 
 import Agda.Compiler.Rust.CommonTypes ( Options(..), CompiledDef, ModuleEnv )
 import Agda.Compiler.Rust.ToRustCompiler ( compile, compileModule )
+import Agda.Compiler.Rust.PrettyPrintingUtils ( prettyPrintRustExpr )
 
 runRustBackend :: IO ()
 runRustBackend = runAgda [Backend backend]
@@ -79,9 +80,9 @@ writeModule :: Options
 writeModule opts _ _ mName cdefs = do
   outDir <- compileDir
   compileLog $ "compiling " <> fileName
-  unless (all null cdefs) $ liftIO
+  unless (null cdefs) $ liftIO
     $ writeFile (outFile outDir)
-    $ compileModule mName cdefs
+    $ prettyPrintRustExpr (compileModule mName cdefs)
   where
     fileName = rustFileName mName
     dirName outDir = fromMaybe outDir (optOutDir opts)

--- a/src/Agda/Compiler/Rust/Backend.hs
+++ b/src/Agda/Compiler/Rust/Backend.hs
@@ -23,8 +23,8 @@ import Agda.TypeChecking.Monad (
   setScope )
 
 import Agda.Compiler.Rust.CommonTypes ( Options(..), CompiledDef, ModuleEnv )
-import Agda.Compiler.Rust.ToRustCompiler ( compile, compileModule )
-import Agda.Compiler.Rust.PrettyPrintingUtils ( prettyPrintRustExpr )
+import Agda.Compiler.Rust.AgdaToRustExpr ( compile, compileModule )
+import Agda.Compiler.Rust.PrettyPrintRustExpr ( prettyPrintRustExpr )
 
 runRustBackend :: IO ()
 runRustBackend = runAgda [Backend backend]

--- a/src/Agda/Compiler/Rust/CommonTypes.hs
+++ b/src/Agda/Compiler/Rust/CommonTypes.hs
@@ -3,8 +3,10 @@ module Agda.Compiler.Rust.CommonTypes (
   CompiledDef,
   ModuleEnv ) where
 
+import Agda.Compiler.Rust.RustExpr ( RustExpr )
+
 data Options = Options { optOutDir :: Maybe FilePath }
 
-type CompiledDef = String
+type CompiledDef = RustExpr
 
 type ModuleEnv = ()

--- a/src/Agda/Compiler/Rust/PrettyPrintRustExpr.hs
+++ b/src/Agda/Compiler/Rust/PrettyPrintRustExpr.hs
@@ -1,4 +1,4 @@
-module Agda.Compiler.Rust.PrettyPrintRustExpr ( prettyPrintRustExpr ) where
+module Agda.Compiler.Rust.PrettyPrintRustExpr ( prettyPrintRustExpr, moduleHeader ) where
 
 import Data.List ( intersperse )
 import Agda.Compiler.Rust.CommonTypes ( CompiledDef )
@@ -61,4 +61,3 @@ prettyPrintFunctionBody fBody = "return" <> exprSeparator <> fBody <> ";"
 
 moduleHeader :: String -> String
 moduleHeader mName = "mod" <> exprSeparator <> mName <> exprSeparator
-

--- a/src/Agda/Compiler/Rust/PrettyPrintRustExpr.hs
+++ b/src/Agda/Compiler/Rust/PrettyPrintRustExpr.hs
@@ -1,4 +1,4 @@
-module Agda.Compiler.Rust.PrettyPrintingUtils ( prettyPrintRustExpr ) where
+module Agda.Compiler.Rust.PrettyPrintRustExpr ( prettyPrintRustExpr ) where
 
 import Data.List ( intersperse )
 import Agda.Compiler.Rust.CommonTypes ( CompiledDef )

--- a/src/Agda/Compiler/Rust/PrettyPrintingUtils.hs
+++ b/src/Agda/Compiler/Rust/PrettyPrintingUtils.hs
@@ -1,13 +1,36 @@
-module Agda.Compiler.Rust.PrettyPrintingUtils (
-  argList,
-  bracket,
-  combineLines,
-  defsSeparator,
-  exprSeparator,
-  funReturnTypeSeparator,
-  indent,
-  typeSeparator
-) where
+module Agda.Compiler.Rust.PrettyPrintingUtils ( prettyPrintRustExpr ) where
+
+import Data.List ( intersperse )
+import Agda.Compiler.Rust.CommonTypes ( CompiledDef )
+import Agda.Compiler.Rust.RustExpr ( RustExpr(..), RustElem(..), FunBody )
+
+prettyPrintRustExpr :: CompiledDef -> String
+prettyPrintRustExpr def = case def of
+  (TeEnum name fields) ->
+    "enum" <> exprSeparator
+      <> name
+      <> exprSeparator
+      <> bracket (
+        indent -- TODO this to siplistic indentation
+        <> concat (intersperse ", " fields))
+  (TeFun fName (RustElem aName aType) resType fBody) ->
+      "pub fn" <> exprSeparator
+        <> fName
+        <> argList (
+          aName
+          <> typeSeparator <> exprSeparator
+          <> aType )
+        <> exprSeparator <> funReturnTypeSeparator <> exprSeparator <> resType
+        <> exprSeparator <> bracket (
+        -- TODO proper indentation for every line of function body
+        -- including nested expressions
+        indent
+        <> (prettyPrintFunctionBody fBody))
+        <> defsSeparator
+  (TeMod mName defs) ->
+    moduleHeader mName
+    <> bracket (combineLines (map prettyPrintRustExpr defs))
+    <> defsSeparator
 
 bracket :: String -> String
 bracket str = "{\n" <> str <> "\n}"
@@ -32,3 +55,10 @@ funReturnTypeSeparator = "->"
 
 combineLines :: [String] -> String
 combineLines xs = unlines (filter (not . null) xs)
+
+prettyPrintFunctionBody :: FunBody -> String
+prettyPrintFunctionBody fBody = "return" <> exprSeparator <> fBody <> ";"
+
+moduleHeader :: String -> String
+moduleHeader mName = "mod" <> exprSeparator <> mName <> exprSeparator
+

--- a/src/Agda/Compiler/Rust/RustExpr.hs
+++ b/src/Agda/Compiler/Rust/RustExpr.hs
@@ -1,0 +1,21 @@
+module Agda.Compiler.Rust.RustExpr (
+  RustName,
+  RustType,
+  RustExpr(..),
+  RustElem(..),
+  FunBody
+  ) where
+
+type RustName = String
+type RustType = String
+type FunBody = String
+
+data RustElem = RustElem RustName RustType
+  deriving ( Show )
+
+data RustExpr
+  = TeMod RustName [RustExpr]
+  | TeEnum RustName [RustName]
+  | TeFun RustName RustElem RustType FunBody
+  | Unhandled RustName String
+  deriving ( Show )

--- a/test/RustBackendTest.hs
+++ b/test/RustBackendTest.hs
@@ -7,7 +7,7 @@ import Test.HUnit (
   , runTestTT)
 import System.Exit ( exitFailure , exitSuccess )
 import Agda.Compiler.Rust.Backend ( backend, defaultOptions )
-import Agda.Compiler.Rust.AgdaToRustExpr ( moduleHeader )
+import Agda.Compiler.Rust.PrettyPrintRustExpr ( moduleHeader )
 
 import Agda.Compiler.Backend ( isEnabled )
 

--- a/test/RustBackendTest.hs
+++ b/test/RustBackendTest.hs
@@ -7,7 +7,7 @@ import Test.HUnit (
   , runTestTT)
 import System.Exit ( exitFailure , exitSuccess )
 import Agda.Compiler.Rust.Backend ( backend, defaultOptions )
-import Agda.Compiler.Rust.ToRustCompiler ( moduleHeader )
+import Agda.Compiler.Rust.AgdaToRustExpr ( moduleHeader )
 
 import Agda.Compiler.Backend ( isEnabled )
 


### PR DESCRIPTION
## Changes

First step towards design proposed in #14 - separate traversing Agda compiler internal representation and pretty printing using RustExpr